### PR TITLE
fixed basedir parameter to ltss.compileString

### DIFF
--- a/tasks/ltss.js
+++ b/tasks/ltss.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
 
       // Handle options.
       src += options.punctuation;
-      ltss.compileString(src, path.dirname(src), function(err, data) {
+      ltss.compileString(src, path.dirname(f.src), function(err, data) {
         // Write the destination file.
         grunt.file.write(f.dest, data);
 


### PR DESCRIPTION
In one of my projects `src` was the contents of the file, changing it to `f.src` gave the correct path.
